### PR TITLE
Load article content asynchronously

### DIFF
--- a/feedi/routes.py
+++ b/feedi/routes.py
@@ -312,25 +312,15 @@ def entry_view(id):
     # browser behavior. I don't like it, but I couldn't figure out how to preserve the feed
     # page/scrolling position on back button unless I jump to view content via htmx
 
-    # FIXME refactor for sharing the async loading with preview
-    def do_extract():
+    if 'HX-Request' in flask.request.headers and not 'content' in flask.request.args:
+        # if ajax/htmx just load the empty UI and load content asynchronously
+        content = None
+    else:
+        # if full browser load or explicit content request, fetch the article synchronously
         content = extract_article(
             entry.content_url, entry.feed.javascript_enabled)['content']
         entry.feed.score += 1
         db.session.commit()
-        return content
-
-    content = None
-    if 'HX-Request' in flask.request.headers:
-        if 'content' in flask.request.args:
-            # if content flag, this is the UI asking for the article html after loading the layout
-            content = do_extract()
-        else:
-            # if no content flag just return the empty UI and load asynchronously
-            pass
-    else:
-        # if full browser load, fetch the article synchronously
-        content = do_extract()
 
     return flask.render_template("entry_content.html", entry=entry, content=content)
 

--- a/feedi/templates/base.html
+++ b/feedi/templates/base.html
@@ -11,7 +11,7 @@
     <title>Feedi {% block title %}{% endblock %}</title>
     <meta name="htmx-config" content='{"refreshOnHistoryMiss": true}'>
     </head>
-    <body hx-boost="true">
+    <body>
     <nav class="navbar is-hidden-tablet is-fixed-top is-light" role="navigation" aria-label="main navigation">
         <div class="navbar-brand">
             <a class="navbar-item"
@@ -96,7 +96,7 @@
                 {% endblock %}
             </div>
             <div class="column is-centered is-two-thirds is-paddingless">
-                <div id="entry-list">
+                <div id="entry-list" hx-boost="true">
                     {% block content %}{% endblock %}
                 </div>
             </div>

--- a/feedi/templates/entry_content.html
+++ b/feedi/templates/entry_content.html
@@ -44,7 +44,21 @@
   </div>
     </article>
     <div class="content entry-content">
+        {% if content %}
         {{ content | safe }}
+        {% else %}
+        <div class="buttons is-centered"
+             hx-get="{{url_for('entry_view', id=entry.id, content='true' )}}"
+             hx-trigger="revealed"
+             hx-swap="outerHTML"
+             hx-select=".entry-content"
+             hx-target=".entry-content">
+            <br/>
+            <button class="button is-loading is-large is-centered " style="border: none;">
+            Button
+            </button>
+        </div>
+        {% endif %}
     </div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
This changes the way the article content fetching works: now the layout of the page loads immediately and the content is fetched with ajax/htmx. This is done to have indication of loading for the user while preserving the htmx boosting (which we need to preserve scrolling position when going back to the feed).

The boosting was disabled for non feed interactions (e.g. when triggering a preview from the autocomplete), to rely on browser loading indicators in that case.