### PR TITLE
Add fallback for when RSS entry has no title

### DIFF
--- a/feedi/sources/rss.py
+++ b/feedi/sources/rss.py
@@ -14,6 +14,12 @@ logger = logging.getLogger(__name__)
 feedparser.USER_AGENT = USER_AGENT
 
 
+def strip_html(text):
+    """Remove html tags from a string"""
+    import re
+    clean = re.compile('<.*?>|<.*?$')
+    return re.sub(clean, '', text)
+
 def get_best_parser(url):
     # Try with all the customized parsers, and if none is compatible default to the generic RSS parsing.
     for cls in RSSParser.__subclasses__():
@@ -87,7 +93,10 @@ class RSSParser(BaseParser):
         return True
 
     def parse_title(self, entry):
-        return entry['title']
+        if entry.has_key('title'):  # Not required by RSS spec
+            return entry['title']
+        else:  # Return first 10 words of description
+            return strip_html(' '.join(entry['description'].split()[:10]))
 
     def parse_content_url(self, entry):
         return entry['link']

--- a/feedi/sources/rss.py
+++ b/feedi/sources/rss.py
@@ -14,12 +14,6 @@ logger = logging.getLogger(__name__)
 feedparser.USER_AGENT = USER_AGENT
 
 
-def strip_html(text):
-    """Remove html tags from a string"""
-    import re
-    clean = re.compile('<.*?>|<.*?$')
-    return re.sub(clean, '', text)
-
 def get_best_parser(url):
     # Try with all the customized parsers, and if none is compatible default to the generic RSS parsing.
     for cls in RSSParser.__subclasses__():
@@ -95,8 +89,12 @@ class RSSParser(BaseParser):
     def parse_title(self, entry):
         if entry.has_key('title'):  # Not required by RSS spec
             return entry['title']
-        else:  # Return first 10 words of description
-            return strip_html(' '.join(entry['description'].split()[:10]))
+        else:  # Fallback
+            max_words = 10
+            soup = BeautifulSoup(entry['summary'], 'lxml')
+            quote = ' '.join(soup.text.split()[:max_words])
+            return quote
+            # return f'@{self.parse_username(entry)}: "{quote}..."'  # Will look nice once the below Todo is fixed
 
     def parse_content_url(self, entry):
         return entry['link']


### PR DESCRIPTION
As per W3C's feed validator, RSS feeds that have no `<title>` in an `<item>` are still valid. With this PR, feeds like https://mastodon.social/tags/Internet.rss that validate but are not supported by feedi will be properly displayed. Also strips nasty HTML tags from the title.

Also open to adding the author to this title.

Feed for `#Internet` on mastodon.social:
![Feedi display for the RSS feed associated with the Internet tag](https://github.com/facundoolano/feedi/assets/59982409/797d11ea-0905-4fb2-9d1c-b9901ef51e45)
