### PR TITLE
Prefer external links over local reader

### DIFF
--- a/feedi/filters.py
+++ b/feedi/filters.py
@@ -70,13 +70,12 @@ def sanitize_content(html):
 # to make the text hide on overflow
 @app.template_filter('entry_excerpt')
 def entry_excerpt(entry):
-    # FIXME this duplicates template logic, move to helper
     if not entry.body:
         return
 
-    if entry.title and entry.content_url:
+    if entry.has_content():
         title = entry.title
-    elif entry.avatar_url:
+    elif entry.has_distinct_user():
         title = entry.display_name or entry.username
     else:
         title = entry.feed.name

--- a/feedi/models.py
+++ b/feedi/models.py
@@ -299,6 +299,28 @@ class Entry(db.Model):
     def __repr__(self):
         return f'<Entry {self.feed_id}/{self.remote_id}>'
 
+    def has_content(self):
+        """
+        Returns True if this entry has associated content (with a title and a remote url).
+        This would be the case for blogs, news sites, etc., but not for mastodon toots or
+        notification streams.
+        """
+        return self.title and self.content_url
+
+    def has_distinct_user(self):
+        """
+        Returns True if this entry has a recognizable author, particularly that
+        it has an avatar and a name that can be displayed instead of a generic feed icon.
+        """
+        return self.avatar_url and (self.display_name or self.username)
+
+    def has_comments_url(self):
+        """
+        Returns True if this entry has a distinct comments/discussion endpoint,
+        separate from the content site. (E.g. link agreggators and mastodon toots).
+        """
+        return self.entry_url and self.content_url != self.entry_url
+
     @classmethod
     def _filtered_query(cls, hide_seen=False, favorited=None,
                         feed_name=None, username=None, folder=None,

--- a/feedi/routes.py
+++ b/feedi/routes.py
@@ -306,28 +306,15 @@ def entry_view(id):
         # this view can't work if no entry or content url
         return "Entry not readable", 400
 
-    # Handle the cases when we should redirect instead of trying to render locally.
-    # either because the UI requests it explicitly, or because the source content is not
-    # renderable locally (e.g. it's a pdf or a video)
     redirect_url = None
-    redirect_arg = flask.request.args.get('redirect')
-    if redirect_arg == 'entry' and entry.entry_url:
-        redirect_url = entry.entry_url
-    elif redirect_arg == 'content' and entry.content_url:
-        redirect_url = entry.content_url
-    else:
-        res = requests.head(dest_url)
+    res = requests.head(dest_url)
 
+    if not res.ok:
+        app.logger.error("Can't open entry url", res)
+        return "Can't open entry url", 500
+    elif res.headers.get('Content-Type', '').startswith('application/'):
+        # if the content type is application eg youtube video or pdf, don't try to render locally
         # TODO we could handle urls known to be video here as well eg youtube, vimeo
-
-        if not res.ok:
-            app.logger.error("Can't open entry url", res)
-            return "Can't open entry url", 500
-        elif res.headers.get('Content-Type', '').startswith('application/'):
-            # if the content type is application eg youtube video or pdf, don't try to render locally
-            redirect_url = dest_url
-
-    if redirect_url:
         entry.feed.score += 1
         db.session.commit()
 
@@ -336,7 +323,7 @@ def entry_view(id):
             response.headers['HX-Redirect'] = dest_url
             return response
         else:
-            return flask.redirect(redirect_url)
+            return flask.redirect(dest_url)
 
     # When requested through htmx (ajax), this page loads layout first, then the content
     # on a separate request. The reason for this is that article fetching is slow, and we

--- a/feedi/templates/entry_commands.html
+++ b/feedi/templates/entry_commands.html
@@ -1,9 +1,7 @@
-{% if entry.content_url and entry.id %}
-<a href="{{ url_for('entry_view', id=entry.id, redirect='content') }}" target="_blank" class="dropdown-item"><span class="icon"><i class="fas fa-external-link-alt"></i></span> Go to source</a>
-{% elif entry.content_url %}
-<a href="{{ entry.content_url }}" target="_blank" class="dropdown-item"><span class="icon"><i class="fas fa-external-link-alt"></i></span> Go to source</a>
-{% endif %}
 {% if entry.content_url %}
+{% if entry.id %}
+<a href="{{ url_for('entry_view', id=entry.id) }}" target="_blank" class="dropdown-item"><span class="icon"><i class="fas fa-book-reader"></i></span> View in reader</a>
+{% endif %}
 <a class="dropdown-item" _="on click writeText('{{ entry.content_url }}') into the navigator's clipboard"><span class="icon"><i class="fas fa-link"></i></span> Copy URL</a>
 <a class="dropdown-item" hx-post="{{ url_for('send_to_kindle', url=entry.content_url ) }}"
    _="on htmx:beforeRequest or htmx:afterRequest toggle .fa-spin on <i/> in me"
@@ -12,7 +10,9 @@
 {% if not entry.entry_url or entry.content_url != entry.entry_url %}
 <a href="{{ url_for('feed_add', discover=entry.content_url) }}" class="dropdown-item"><span class="icon"><i class="fas fa-rss"></i></span> Discover feed</a>
 {% endif %}
+
 <hr class="dropdown-divider">
+
 {% endif %}
 {% if entry.username %}
 <a class="dropdown-item" href="{{ url_for('entry_list', username=entry.username ) }}"><span class="icon"><i class="fas fa-user"></i></span> View {{ entry.username }}</a>

--- a/feedi/templates/entry_commands.html
+++ b/feedi/templates/entry_commands.html
@@ -1,6 +1,6 @@
 {% if entry.content_url %}
-{% if entry.id %}
-<a href="{{ url_for('entry_view', id=entry.id) }}" target="_blank" class="dropdown-item"><span class="icon"><i class="fas fa-book-reader"></i></span> View in reader</a>
+{% if entry.id and request.path != url_for('entry_view', id=entry.id) %}
+<a href="{{ url_for('entry_view', id=entry.id) }}" class="dropdown-item"><span class="icon"><i class="fas fa-book-reader"></i></span> View in reader</a>
 {% endif %}
 <a class="dropdown-item" _="on click writeText('{{ entry.content_url }}') into the navigator's clipboard"><span class="icon"><i class="fas fa-link"></i></span> Copy URL</a>
 <a class="dropdown-item" hx-post="{{ url_for('send_to_kindle', url=entry.content_url ) }}"

--- a/feedi/templates/entry_header.html
+++ b/feedi/templates/entry_header.html
@@ -7,11 +7,10 @@
             <b>
                 {% if entry.title and entry.content_url %}
                 <a _="
-                      on keydown[key is 'Enter' and metaKey and shiftKey ] from the closest .feed-entry go to url '{{ url_for("entry_view", id=entry.id, redirect="content") }}' in new window then halt
-                   on keydown[key is 'Enter' and metaKey and not shiftKey] from the closest .feed-entry go to url '{{ url_for("entry_view", id=entry.id )}}' in new window then halt
+                      on keydown[key is 'Enter' and metaKey and shiftKey ] from the closest .feed-entry go to url '{{ url_for("entry_view", id=entry.id) }}' in new window then halt
                    on keydown[key is 'Enter' and not metaKey and not shiftKey] from the closest .feed-entry go to url '{{ url_for("entry_view", id=entry.id )}}'
-                   then on click[metaKey and shiftKey] go to url '{{ url_for("entry_view", id=entry.id, redirect="content") }}' in new window then halt"
-                   href="{{ url_for('entry_view', id=entry.id )}}">{{ entry.title | safe }}</a>
+                   then on click[metaKey and shiftKey] go to url '{{ url_for("entry_view", id=entry.id) }}' in new window then halt"
+                   href="{{ entry.content_url }}">{{ entry.title | safe }}</a>
                 {% elif entry.avatar_url %}
                 <a href="{{ url_for('entry_list', username=entry.username ) }}">
                     {{ entry.display_name or entry.username }}

--- a/feedi/templates/entry_header.html
+++ b/feedi/templates/entry_header.html
@@ -6,11 +6,10 @@
         <p>
             <b>
                 {% if entry.title and entry.content_url %}
-                <a _="
-                      on keydown[key is 'Enter' and metaKey and shiftKey ] from the closest .feed-entry go to url '{{ url_for("entry_view", id=entry.id) }}' in new window then halt
-                   on keydown[key is 'Enter' and not metaKey and not shiftKey] from the closest .feed-entry go to url '{{ url_for("entry_view", id=entry.id )}}'
-                   then on click[metaKey and shiftKey] go to url '{{ url_for("entry_view", id=entry.id) }}' in new window then halt"
-                   href="{{ entry.content_url }}">{{ entry.title | safe }}</a>
+                <a _="on click[shiftKey and not metaKey] or keydown[key is 'Enter' and not metaKey and shiftKey ] from the closest .feed-entry go to url '{{ url_for("entry_view", id=entry.id) }}' then halt
+                   then on click[shiftKey and metaKey] or keydown[key is 'Enter' and metaKey and shiftKey ] from the closest .feed-entry go to url '{{ url_for("entry_view", id=entry.id) }}' in new window then halt
+                   then on keydown[key is 'Enter' and not metaKey and not shiftKey] from the closest .feed-entry go to url '{{ entry.content_url }}' in new window then halt"
+                   href="{{ entry.content_url }}" target="_blank">{{ entry.title | safe }}</a>
                 {% elif entry.avatar_url %}
                 <a href="{{ url_for('entry_list', username=entry.username ) }}">
                     {{ entry.display_name or entry.username }}

--- a/feedi/templates/entry_header.html
+++ b/feedi/templates/entry_header.html
@@ -5,12 +5,12 @@
         </div>
         <p>
             <b>
-                {% if entry.title and entry.content_url %}
+                {% if entry.has_content() %}
                 <a _="on click[shiftKey and not metaKey] or keydown[key is 'Enter' and not metaKey and shiftKey ] from the closest .feed-entry go to url '{{ url_for("entry_view", id=entry.id) }}' then halt
                    then on click[shiftKey and metaKey] or keydown[key is 'Enter' and metaKey and shiftKey ] from the closest .feed-entry go to url '{{ url_for("entry_view", id=entry.id) }}' in new window then halt
                    then on keydown[key is 'Enter' and not metaKey and not shiftKey] from the closest .feed-entry go to url '{{ entry.content_url }}' in new window then halt"
                    href="{{ entry.content_url }}" target="_blank">{{ entry.title | safe }}</a>
-                {% elif entry.avatar_url %}
+                {% elif entry.has_distinct_user() %}
                 <a href="{{ url_for('entry_list', username=entry.username ) }}">
                     {{ entry.display_name or entry.username }}
                 </a>
@@ -30,7 +30,7 @@
         </p>
     </div>
     <div class="is-hidden compact-actions is-hidden">
-        {% if entry.entry_url and entry.content_url != entry.entry_url %}
+        {% if entry.has_comments_url() %}
         <a tabindex="-1" class="level-item icon hover-icon is-white is-rounded" title="Comment"
            href="{{ entry.entry_url}}" target="_blank"
         ><i class="fas fa-comment-alt"></i></a>
@@ -54,7 +54,7 @@
            _="on click toggle .toggled
                      then on keyup[key is 'f'] from the closest .feed-entry trigger click on me"
         ><i class="fas fa-star"></i></a>
-        {% if entry.entry_url and entry.content_url != entry.entry_url %}
+        {% if entry.has_comments_url() %}
         <a tabindex="-1" class="level-item icon hover-icon is-white is-rounded" title="Comment"
            href="{{ entry.entry_url}}" target="_blank"
         ><i class="fas fa-comment-alt"></i></a>

--- a/feedi/templates/entry_list_page.html
+++ b/feedi/templates/entry_list_page.html
@@ -68,7 +68,7 @@
             _="on click toggle .toggled"
          ><i class="fas fa-star"></i></a>
 
-        {% if entry.entry_url and entry.content_url != entry.entry_url %}
+        {% if entry.has_comments_url() %}
         <a class="icon is-white is-rounded level-item" title="Comment"
            href="{{ entry.entry_url}}" target="_blank">
             <i class="fas fa-comment-alt"></i>


### PR DESCRIPTION
This changes the UI so the default action for entries is to go to the source of the article when clicked, instead of opening in the reader. The rationale is that the reader tends to be slower and not worth it for most of the news, so a better default is to go to the source. The reader can still be accessed with alternate keybindings and via the entry commands menu.

(I will review the usefulness of the reader functionality and may remove it entirely in the future)