### PR TITLE
Improve score scorting

### DIFF
--- a/feedi/models.py
+++ b/feedi/models.py
@@ -164,7 +164,7 @@ class Feed(db.Model):
 
     @classmethod
     def averaged_score_query(cls):
-        return db.select(cls.id, (cls.score * 100.0 / sa.func.count(cls.id)).label('avg_score'))\
+        return db.select(cls.id, sa.func.round(cls.score * 100.0 / sa.func.count(cls.id)).label('avg_score'))\
             .join(Entry)\
             .group_by(cls)\
             .subquery()

--- a/feedi/models.py
+++ b/feedi/models.py
@@ -162,6 +162,20 @@ class Feed(db.Model):
                   .join(subquery, subquery.c.id == self.id)
         return db.session.scalar(query)
 
+    @classmethod
+    def averaged_score_query(cls):
+        return db.select(cls.id, (cls.score * 100.0 / sa.func.count(cls.id)).label('avg_score'))\
+            .join(Entry)\
+            .group_by(cls)\
+            .subquery()
+
+    def averaged_score(self):
+        subquery = self.averaged_score_query()
+        query = db.select(subquery.c.avg_score)\
+                  .select_from(Feed)\
+                  .join(subquery, subquery.c.id == self.id)
+        return db.session.scalar(query)
+
 
 class RssFeed(Feed):
     etag = sa.Column(
@@ -383,13 +397,16 @@ class Entry(db.Model):
             return query.order_by(cls.remote_updated.desc())
 
         elif ordering == cls.ORDER_SCORE:
-            # order by score but within 6 hour buckets, so we don't get everything from the top score feed
-            # first, then the 2nd, etc
+            subquery = Feed.averaged_score_query()
+
+            # order by score but within 8-hour buckets, so we don't get everything from the top score feed
+            # first, then the 2nd, etc.
             return query.join(Feed)\
+                        .join(subquery, Feed.id == subquery.c.id)\
                         .order_by(
                             sa.func.DATE(cls.remote_updated).desc(),
-                            sa.func.round(sa.func.extract('hour', cls.remote_updated) / 6).desc(),
-                            Feed.score.desc(),
+                            sa.func.round(sa.func.extract('hour', cls.remote_updated) / 8).desc(),
+                            subquery.c.avg_score.desc(),
                             cls.remote_updated.desc())
 
         elif ordering == cls.ORDER_FREQUENCY:

--- a/feedi/routes.py
+++ b/feedi/routes.py
@@ -43,6 +43,14 @@ def entry_list(**filters):
     (entries, next_page) = fetch_entries_page(page, ordering, hide_seen, is_mixed_feed_list,
                                               **filters)
 
+    if 'feed_name' in filters:
+        # increase score when viewing a feed
+        update = db.update(models.Feed)\
+                   .where(models.Feed.name == filters['feed_name'])\
+                   .values(score=models.Feed.score + 1)
+        db.session.execute(update)
+        db.session.commit()
+
     if page:
         # if it's a paginated request, render a single page of the entry list
         return flask.render_template('entry_list_page.html',

--- a/feedi/templates/feed_edit.html
+++ b/feedi/templates/feed_edit.html
@@ -54,20 +54,24 @@
              _="on load or change from <select[name='type']/> if (the value of the previous <select[name='type']/>) includes('mastodon') then add .is-hidden else remove .is-hidden end"
         >
             <label class="label">Filters</label>
-            <p class="help">A comma-separated list of field=value expressions to be used to filter items from the source when parsing the feed entries.</p>
             <div class="control">
                 <input class="input" name="filters" type="text" {% if feed and feed.filters %}value="{{ feed.filters }}" {% endif %}>
             </div>
+            <p class="help">A comma-separated list of field=value expressions to be used to filter items from the source when parsing the feed entries.</p>
         </div>
 
         {% if feed %}
-        <div class="field">
-            <label class="label">Score</label>
-            <p class="help">A count of views, pins, favorites and deletes of entries of this feed. It can be overridden to tweak the "best score" sorting.</p>
+        <div class="field is-grouped">
             <div class="control">
-                <input class="input" name="score" type="text" {% if feed and feed.folder %}value="{{ feed.score }}"{% endif %}>
+                <label class="label">Score</label>
+                <input class="input" name="score" type="text" value="{{ feed.score }}">
+            </div>
+            <div class="control">
+                <label class="label">Avg. score</label>
+                <input class="input" name="score" type="text" value="{{ feed.averaged_score() }}">
             </div>
         </div>
+        <p class="help">A count of views, pins, favorites and deletes of entries of this feed. It can be overridden to tweak the "best score" sorting.</p>
 
         <div class="field">
             <label class="label">Frequency rank</label>


### PR DESCRIPTION
Trying to make it more useful by factoring post frequency in the score calculation.

Also increasing the score when filtering by feed name. Note that after changes in #43, we'll lose accuracy since we don't increase score when going to source (this seemed preferable than the UX overhead of going to the backend and redirecting. We could potentially make a separate inc score request, but at the moment I'm trying to figure out if score sorting is worth at all or it should be removed).