### PR TITLE
Experiment with task locking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,12 @@ prod:
 	$(venv) gunicorn
 
 # FIXME this is hacky
+BRANCH ?= main
 prod-update:
 	git stash # because of prod config
-	git checkout main
-	git pull origin main --ff-only
+	git fetch
+	git checkout $(BRANCH)
+	git pull origin $(BRANCH) --ff-only
 	git stash apply
 	make deps
 	$(venv) alembic upgrade head

--- a/feedi/parsers/rss.py
+++ b/feedi/parsers/rss.py
@@ -206,6 +206,8 @@ class RSSParser(CachingRequestsMixin):
             if not url:
                 return
             summary = self.fetch_meta(url, 'og:description', 'description')
+            if not summary:
+                return
 
         soup = BeautifulSoup(summary, 'lxml')
 

--- a/feedi/routes.py
+++ b/feedi/routes.py
@@ -34,12 +34,14 @@ def entry_list(**filters):
     page = flask.request.args.get('page')
     hide_seen = flask.session.get('hide_seen', True)
     ordering = flask.session.get('ordering', models.Entry.ORDER_FREQUENCY)
-    is_mixed_feed_list = filters.get('folder') or flask.request.path == '/'
 
     filters = dict(**filters)
     text = flask.request.args.get('q', '').strip()
     if text:
         filters['text'] = text
+
+    is_mixed_feed_list = filters.get('folder') or (
+        flask.request.path == '/' and not filters.get('text'))
 
     (entries, next_page) = fetch_entries_page(page, ordering, hide_seen, is_mixed_feed_list,
                                               **filters)

--- a/feedi/tasks.py
+++ b/feedi/tasks.py
@@ -92,7 +92,7 @@ def sync_feed(feed_name):
 
 
 @feed_cli.command('purge')
-@huey_task(crontab(minute=app.config['DELETE_OLD_CRON_HOURS']))
+@huey_task(crontab(hour=app.config['DELETE_OLD_CRON_HOURS']))
 def delete_old_entries():
     """
     Delete entries that are older than DELETE_AFTER_DAYS but

--- a/feedi/tasks.py
+++ b/feedi/tasks.py
@@ -44,6 +44,8 @@ def huey_task(*huey_args):
 
                 app.logger.info("STARTING %s %s %s", f.__name__, fargs, fkwargs)
 
+                # using a lock file to ensure a given task is not attempted to run in parallel
+                # so we can have multiple app worker processes without spamming rss sources with redundant requests
                 lock_path = f'{tempfile.gettempdir()}/{f.__name__}-{fargs}-{fkwargs}'.replace(' ', '-')
                 lock = filelock.FileLock(lock_path)
                 try:

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -3,3 +3,4 @@ worker_class = "gevent"
 wsgi_app = "feedi.app:create_app()"
 raw_env = ["FEEDI_CONFIG=feedi/config/prod.py"]
 preload = True
+workers = 4

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -3,4 +3,4 @@ worker_class = "gevent"
 wsgi_app = "feedi.app:create_app()"
 raw_env = ["FEEDI_CONFIG=feedi/config/prod.py"]
 preload = True
-workers = 4
+workers = 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ huey==2.4.5
 alembic==1.11.2
 stkclient==0.1.1
 gunicorn==21.2.0
+filelock==3.12.4


### PR DESCRIPTION
This explores using a lockfile for background tasks so we can run more than one worker process without the cron tasks running multiple times in parallel (and without having to manage a separate task running process).

A lock file lib was used instead of default Huey locking, since the latter it's not supported for MiniHuey.