### PR TITLE
task locking tweaks

### DIFF
--- a/feedi/tasks.py
+++ b/feedi/tasks.py
@@ -11,6 +11,7 @@ from functools import wraps
 
 import click
 import flask
+import flufl.lock as locklib
 import opml
 import sqlalchemy as sa
 from flask import current_app as app
@@ -59,8 +60,36 @@ def huey_task(*huey_args):
     return composed_decorator
 
 
+def locked_task(lifetime):
+    """
+    Wraps a task execution with a file lock acquisition to prevent concurrent execution of the same task.
+    The `lifetime` is the expected runtime of the task, used to expire the lock if for some reason a previous
+    run fails to release it.
+    """
+
+    def decorator(f):
+        lock_path = f'{tempfile.gettempdir()}/{f.__name__}'
+        task_lock = locklib.Lock(lock_path, default_timeout=0)
+        task_lock.lifetime = lifetime
+
+        def inner(*args, **kwargs):
+
+            app.logger.debug("locking %s", lock_path)
+
+            try:
+                with task_lock:
+                    return f(*args, *kwargs)
+            except (locklib.TimeOutError, locklib.AlreadyLockedError):
+                app.logger.info("skipping locked task %s", lock_path)
+
+        return inner
+
+    return decorator
+
+
 @feed_cli.command('sync')
 @huey_task(crontab(minute=app.config['SYNC_FEEDS_CRON_MINUTES']))
+@locked_task(lifetime=300)
 def sync_all_feeds():
     feeds = db.session.execute(db.select(models.Feed.id, models.Feed.name)).all()
 
@@ -89,6 +118,7 @@ def sync_feed(feed_id, _feed_name):
 
 @feed_cli.command('purge')
 @huey_task(crontab(minute='0', hour=app.config['DELETE_OLD_CRON_HOURS']))
+@locked_task(lifetime=20)
 def delete_old_entries():
     """
     Delete entries that are older than DELETE_AFTER_DAYS but

--- a/feedi/tasks.py
+++ b/feedi/tasks.py
@@ -10,7 +10,6 @@ import tempfile
 from functools import wraps
 
 import click
-import filelock
 import flask
 import opml
 import sqlalchemy as sa
@@ -49,16 +48,8 @@ def huey_task(*huey_args):
 
                 app.logger.info("STARTING %s %s %s", f.__name__, fargs, fkwargs)
 
-                # using a lock file to ensure a given task is not attempted to run in parallel
-                # so we can have multiple app worker processes without spamming rss sources with redundant requests
-                lock_path = f'{tempfile.gettempdir()}/{f.__name__}-{fargs}-{fkwargs}'.replace(' ', '-')
-                lock = filelock.FileLock(lock_path)
-                try:
-                    with lock.acquire(blocking=False):
-                        f(*args, **kwargs)
-                        app.logger.info("FINISHED %s %s %s", f.__name__, fargs, fkwargs)
-                except filelock.Timeout:
-                    app.logger.info("SKIPPING locked task %s", lock_path)
+                f(*args, **kwargs)
+                app.logger.info("FINISHED %s %s %s", f.__name__, fargs, fkwargs)
 
         return decorator
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ stkclient==0.1.1
 gunicorn==21.2.0
 pyopml==1.0.0
 flask-login==0.6.2
+flufl.lock==8.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,5 @@ huey==2.4.5
 alembic==1.11.2
 stkclient==0.1.1
 gunicorn==21.2.0
-filelock==3.12.4
 pyopml==1.0.0
 flask-login==0.6.2


### PR DESCRIPTION
* Change the library to one that supports expiration of locks, since I observed deadlocks when running the server for sometime.
* Move the locking to a separate decorator and apply it only to the top level sync tasks, since I only need it to lock the periodic syncing tasks.

Note that I'm still not positive this complexity is worth over the benefit of running multiple workers of the app. I may revisit and remove locking altogether later.