### PR TITLE
Use gevent + sqlalchemy pooling to prevent leaking sqlite connections

### DIFF
--- a/feedi/app.py
+++ b/feedi/app.py
@@ -49,6 +49,11 @@ def create_huey_app():
     load_config(app)
 
     with app.app_context():
+        # since huey tasks share the db engine pool, we want to have a big enough pool
+        # so all concurrent tasks get their own connection
+        pool_size = round(app.config['HUEY_POOL_SIZE'] * 1.1)
+        app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {'pool_size': pool_size}
+
         models.init_db(app)
 
     return app

--- a/feedi/config/default.py
+++ b/feedi/config/default.py
@@ -11,6 +11,10 @@ DELETE_AFTER_DAYS = 7
 RSS_MINIMUM_ENTRY_AMOUNT = 5
 MASTODON_FETCH_LIMIT = 50
 
+# How many tasks to allow running concurrently. eg. how many feeds to sync at a time.
+# This affects the sqlalchemy engine pool size
+HUEY_POOL_SIZE = 100
+
 # this is a hack to get personal kindle integration (see readme)
 # a real implementation would require some way for the user to set up this integration
 # from the web, or at least some make target to make the setup reproducible

--- a/feedi/models.py
+++ b/feedi/models.py
@@ -29,6 +29,8 @@ def init_db(app):
         # this should be ~200mb
         dbapi_connection.execute('pragma cache_size = -195313')
 
+        app.logger.debug("Created DB connection")
+
     @sa.event.listens_for(User.__table__, 'after_create')
     def after_create(user_table, connection, **kw):
         email = app.config.get('DEFAULT_AUTH_USER')


### PR DESCRIPTION
The current implementation was leaking sqlite file descriptors each time the periodic task run (~3 per each synced feed),
eventually causing "too many open files" errors and blocking the application.

This is because we are [calling create_huey_app](https://github.com/facundoolano/feedi/blob/HEAD/feedi/tasks.py#L43) inside the decorator, for each task run. This produced a new sqlalchey engine and thus a new connection pool to be created each time, but not released.

One way around this was to explicitly `db.engine.dispose()` as part of the decorator, after the task ran.
But it seems more reasonable to instantiate the huey application once (and this have a single engine/connection pool), and manage the concurrent connections via the pool settings. This PR does that by setting limit to the MiniHuey pool size, and a matching limit to the sql engine connection pool size. This way the max concurrent connections are capped and the same connections can be used again on subsequent cron task runs.

I'll merge this and monitor file descriptor behavior over time to verify it works as expected.