### PR TITLE
Add controls to the footer nav in reader view

### DIFF
--- a/feedi/static/css/main.css
+++ b/feedi/static/css/main.css
@@ -254,13 +254,6 @@ img[src=""] {
     width: 100%;
 }
 
-@media screen and (max-width: 768px) {
-.entry-quick-actions {
-    position: fixed;
-    right: .5rem;
-}
-}
-
 /* FIXME mobile-only, do this properly with sass */
 @media screen and (max-width: 1023px) {
     .entry-content {

--- a/feedi/templates/base.html
+++ b/feedi/templates/base.html
@@ -27,8 +27,8 @@
                 {{ self.sidebar_right() }}
             </div>
         </div>
+        {% block mobile_navbar %}
         <div class="navbar-brand">
-            {% block mobile_navbar %}
             <a class="navbar-item"
                {% if request.endpoint in ['entry_list', 'favorites'] %}
                hx-get="{{ url_for('entry_list', **filters) }}"
@@ -39,8 +39,6 @@
             >
                 <h1 class="title is-4">feedi</h1>
             </a>
-            {% endblock %}
-
             {% if current_user.is_authenticated %}
             <div class="navbar-item navbar-autocomplete" href="/">
                 {% include "autocomplete.html" %}
@@ -54,7 +52,9 @@
                 <span aria-hidden="true"></span>
             </a>
             {% endif %}
+
         </div>
+        {% endblock %}
     </nav>
     <section class="container">
         <div class="columns">

--- a/feedi/templates/entry_content.html
+++ b/feedi/templates/entry_content.html
@@ -22,7 +22,7 @@
 <div class="navbar-brand">
     <div class="navbar-item is-expanded">
         <div class="level is-mobile " style="flex: 1 0 auto;">
-            <a class="is-white icon is-rounded level-item" title="back"
+            <a class="is-white icon is-rounded level-item" title="Back"
                _="on click if history.length == 1 go to url '{{ url_for("entry_list")}}' else go back end"
             >
                 <i class="fas fa-arrow-left fa-lg"></i>
@@ -37,15 +37,20 @@
            href="{{ entry.entry_url}}" target="_blank">
             <i class="fas fa-comment-alt"></i>
         </a>
+        {% else %}
+        <a class="is-white icon is-rounded level-item" title="Go to source"
+           href="{{ entry.content_url}}" target="_blank">
+            <i class="fas fa-external-link-alt"></i>
+        </a>
         {% endif %}
 
-        <a class="level-item icon hover-icon is-white is-rounded {% if entry.pinned %}toggled{% endif %} pin-button" title="Pin entry"
+        <a class="level-item icon hover-icon is-white is-rounded {% if entry.pinned %}toggled{% endif %} pin-button" title="Pin"
            hx-put="{{ url_for('entry_pin', id=entry.id, **filters) }}"
            hx-target="#pinned-entry-list"
            _="on click toggle .toggled on < [data-id='{{entry.id}}'] .pin-button />">
             <i class="fas fa-thumbtack"></i></a>
 
-        <a class="level-item icon hover-icon is-white is-rounded {% if entry.pinned %}toggled{% endif %} pin-button" title="Pin entry"
+        <a class="level-item icon hover-icon is-white is-rounded {% if entry.pinned %}toggled{% endif %} pin-button" title="More"
            _="on click toggle .is-active then toggle .is-active on the previous .navbar-menu"
         >
             <i class="fas fa-bars"></i></a>

--- a/feedi/templates/entry_content.html
+++ b/feedi/templates/entry_content.html
@@ -27,10 +27,12 @@
             >
                 <i class="fas fa-arrow-left fa-lg"></i>
             </a>
+        {% if entry.id %}
         <a class="level-item icon is-white is-rounded {% if entry.favorited %}toggled{% endif %}" title="Favorite"
            hx-put="{{ url_for('entry_favorite', id=entry.id )}}"
            _="on click toggle .toggled"
         ><i class="fas fa-star"></i></a>
+        {% endif %}
 
         {% if entry.has_comments_url() %}
         <a class="is-white icon is-rounded level-item" title="Comment"
@@ -44,11 +46,13 @@
         </a>
         {% endif %}
 
+        {% if entry.id %}
         <a class="level-item icon hover-icon is-white is-rounded {% if entry.pinned %}toggled{% endif %} pin-button" title="Pin"
            hx-put="{{ url_for('entry_pin', id=entry.id, **filters) }}"
            hx-swap="none"
            _="on click toggle .toggled">
             <i class="fas fa-thumbtack"></i></a>
+        {% endif %}
 
         <a class="level-item icon hover-icon is-white is-rounded pin-button" title="More"
            _="on click toggle .is-active then toggle .is-active on the previous .navbar-menu"

--- a/feedi/templates/entry_content.html
+++ b/feedi/templates/entry_content.html
@@ -74,29 +74,6 @@
       <small class="has-text-grey-light"><span title="{{ entry.remote_updated.isoformat() }}">{{ entry.remote_created | humanize }}</span> {% if entry.username %}· {{ entry.username}}{%endif%} {%if entry.content_url %}· {{ entry.content_url | url_domain}}{% endif %}</small>
   </div>
 
-  <div class="media-right">
-      <div class="level entry-quick-actions">
-          <div class="level-left is-hidden-mobile">
-              {% block action_favorite %}
-              <a tabindex="-1" class="level-item icon  is-white is-rounded {% if entry.favorited %}toggled{% endif %}" title="Favorite entry"
-                 hx-put="{{ url_for('entry_favorite', id=entry.id )}}"
-                 _="on click toggle .toggled"
-              ><i class="fas fa-star"></i></a>
-              {% endblock %}
-              {% block action_pin %}
-              <a tabindex="-1" class="level-item icon  is-white is-rounded {% if entry.pinned %}toggled{% endif %} pin-button" title="Pin entry"
-                 hx-put="{{ url_for('entry_pin', id=entry.id, **filters) }}"
-                 hx-swap="none"
-                 _="on click toggle .toggled">
-                  <i class="fas fa-thumbtack"></i></a>
-              {% endblock %}
-          </div>
-          <div class="level-left is-hidden-tablet">
-              {{ self.action_pin() }}
-              {{ self.action_favorite() }}
-          </div>
-      </div>
-  </div>
     </article>
     <div class="content entry-content">
         {% if content %}

--- a/feedi/templates/entry_content.html
+++ b/feedi/templates/entry_content.html
@@ -46,11 +46,11 @@
 
         <a class="level-item icon hover-icon is-white is-rounded {% if entry.pinned %}toggled{% endif %} pin-button" title="Pin"
            hx-put="{{ url_for('entry_pin', id=entry.id, **filters) }}"
-           hx-target="#pinned-entry-list"
-           _="on click toggle .toggled on < [data-id='{{entry.id}}'] .pin-button />">
+           hx-swap="none"
+           _="on click toggle .toggled">
             <i class="fas fa-thumbtack"></i></a>
 
-        <a class="level-item icon hover-icon is-white is-rounded {% if entry.pinned %}toggled{% endif %} pin-button" title="More"
+        <a class="level-item icon hover-icon is-white is-rounded pin-button" title="More"
            _="on click toggle .is-active then toggle .is-active on the previous .navbar-menu"
         >
             <i class="fas fa-bars"></i></a>

--- a/feedi/templates/entry_content.html
+++ b/feedi/templates/entry_content.html
@@ -9,7 +9,7 @@
             <div class="level-left">
                 <div class="level-item">
                     <a _="on click if history.length == 1 go to url '{{ url_for("entry_list")}}' else go back end
-                          then on keyup[key is 'Escape'] elsewhere trigger click on me"
+                       then on keyup[key is 'Escape'] elsewhere trigger click on me"
                     ><icon><i class="fas fa-arrow-left"></i></icon> Back</a>
                 </div>
             </div>
@@ -19,10 +19,44 @@
 {% endblock %}
 
 {% block mobile_navbar %}
-<a class="navbar-item"
-   _="on click if history.length == 1 go to url '{{ url_for("entry_list")}}' else go back end">
-    <h1 class="title is-4 has-text-grey-dark"><i class="fas fa-arrow-left"></i> </h1>
-</a>
+<div class="navbar-brand">
+    <div class="navbar-item is-expanded">
+        <div class="level is-mobile " style="flex: 1 0 auto;">
+            <a class="is-white icon is-rounded level-item" title="back"
+               _="on click if history.length == 1 go to url '{{ url_for("entry_list")}}' else go back end"
+            >
+                <i class="fas fa-arrow-left fa-lg"></i>
+            </a>
+        <a class="level-item icon is-white is-rounded {% if entry.favorited %}toggled{% endif %}" title="Favorite"
+           hx-put="{{ url_for('entry_favorite', id=entry.id )}}"
+           _="on click toggle .toggled"
+        ><i class="fas fa-star"></i></a>
+
+        {% if entry.has_comments_url() %}
+        <a class="is-white icon is-rounded level-item" title="Comment"
+           href="{{ entry.entry_url}}" target="_blank">
+            <i class="fas fa-comment-alt"></i>
+        </a>
+        {% endif %}
+
+        <a class="level-item icon hover-icon is-white is-rounded {% if entry.pinned %}toggled{% endif %} pin-button" title="Pin entry"
+           hx-put="{{ url_for('entry_pin', id=entry.id, **filters) }}"
+           hx-target="#pinned-entry-list"
+           _="on click toggle .toggled on < [data-id='{{entry.id}}'] .pin-button />">
+            <i class="fas fa-thumbtack"></i></a>
+
+        <a class="level-item icon hover-icon is-white is-rounded {% if entry.pinned %}toggled{% endif %} pin-button" title="Pin entry"
+           _="on click toggle .is-active then toggle .is-active on the previous .navbar-menu"
+        >
+            <i class="fas fa-bars"></i></a>
+
+    </div>
+    </div>
+
+</div>
+
+
+
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Instead of taking space from the header and having to scroll backup to perform actions, remove the autocomplete when looking at an entry detail (or previewing an url).

This make sense since I had to add the footer nav anyway to add a back button (at least on iOS, the scroll position is lost when using swipe to go back, which results in a very annoying UX).