### PR TITLE
Open links in local reader

### DIFF
--- a/feedi/filters.py
+++ b/feedi/filters.py
@@ -70,6 +70,7 @@ def sanitize_content(html, truncate=True):
 
         # open links in local reader
         a['href'] = flask.url_for('preview_content', url=a['href'])
+        del a['target']
 
     return str(soup)
 

--- a/feedi/filters.py
+++ b/feedi/filters.py
@@ -66,11 +66,12 @@ def sanitize_content(html, truncate=True):
 
     for a in soup.find_all('a', href=True):
         # prevent link clicks triggering the container's click event
-        a['_'] = "on click halt the event's bubbling"
-
-        # open links in local reader
-        a['href'] = flask.url_for('preview_content', url=a['href'])
-        del a['target']
+        # add kb modifiers to open in reader
+        a['_'] = f"""
+        on click[shiftKey and not metaKey] go to url {flask.url_for("preview_content", url=a["href"])} then halt
+        then on click[shiftKey and metaKey] go to url {flask.url_for("preview_content", url=a["href"])} in new window then halt
+        then on click halt the event's bubbling
+        """
 
     return str(soup)
 

--- a/feedi/routes.py
+++ b/feedi/routes.py
@@ -564,6 +564,7 @@ def extract_article(url, local_links=False):
     if local_links:
         for a in soup.findAll('a', href=True):
             a['href'] = flask.url_for('preview_content', url=a['href'])
+            del a['target']
 
     article['content'] = str(soup)
 

--- a/feedi/routes.py
+++ b/feedi/routes.py
@@ -444,7 +444,7 @@ def entry_view(id):
 
         # if full browser load or explicit content request, fetch the article synchronously
         try:
-            content = extract_article(dest_url)['content']
+            content = extract_article(dest_url, local_links=True)['content']
             return flask.render_template("entry_content.html", entry=entry, content=content)
         except:
             pass
@@ -475,7 +475,7 @@ def preview_content():
     """
     url = flask.request.args['url']
     try:
-        article = extract_article(url)
+        article = extract_article(url, local_links=True)
     except:
         return flask.redirect(url)
 
@@ -539,7 +539,7 @@ def compress_article(outfilename, article):
         zip.writestr('article.html', str(soup))
 
 
-def extract_article(url):
+def extract_article(url, local_links=False):
     # The mozilla/readability npm package shows better results at extracting the
     # article content than all the python libraries I've tried... even than the readabilipy
     # one, which is a wrapper of it. so resorting to running a node.js script on a subprocess
@@ -560,6 +560,10 @@ def extract_article(url):
     # prevent video iframes to force dimensions
     for iframe in soup.findAll('iframe', height=True):
         del iframe['height']
+
+    if local_links:
+        for a in soup.findAll('a', href=True):
+            a['href'] = flask.url_for('preview_content', url=a['href'])
 
     article['content'] = str(soup)
 

--- a/feedi/templates/entry_list_page.html
+++ b/feedi/templates/entry_list_page.html
@@ -58,7 +58,7 @@
                           {% endif %}>
                          <div class="content" tabindex="-1">
                          {% if entry.feed.type == 'mastodon' %}
-                         {{ entry.body | safe }}
+                         {{ entry.body | sanitize(truncate=False) | safe }}
                          {% else %}
                          {{ entry.body | sanitize | safe }}
                              {% endif %}


### PR DESCRIPTION
This updates the html rendering in the entry preview and in the local reader to open links in the local reader by default, rather than in the source site.

This makes it handy when the link is another article, at the expense of making it awkward when it's some other content (like a website's front page, a youtube video, etc.). The assumption is that this case is that the former is more frequent than the latter. I'll try this branch for a while and see how it feels.