### PR TITLE
ui: different folder icon when opened

### DIFF
--- a/feedi/routes.py
+++ b/feedi/routes.py
@@ -142,7 +142,7 @@ def autocomplete():
             .filter(models.Feed.folder.icontains(term),
                     models.Feed.user_id == current_user.id).distinct()
         ).all()
-        options += [(f, flask.url_for('entry_list', folder=f), 'far fa-folder-open')
+        options += [(f, flask.url_for('entry_list', folder=f), 'far fa-folder')
                     for f in folders]
 
         feed_names = db.session.scalars(

--- a/feedi/templates/base.html
+++ b/feedi/templates/base.html
@@ -20,7 +20,7 @@
                 {% if shortcut_folders %}
                 {% for folder in shortcut_folders %}
                 <a class="dropdown-item {% if filters.folder == folder %}is-active"{% endif %}" href="{{ url_for('entry_list', folder=folder ) }}">
-                    <icon class="icon"><i class="far fa-folder-open"></i></icon> {{ folder }}</a>
+                    <icon class="icon"><i class="far {% if filters.folder == folder %}fa-folder-open{% else %}fa-folder{% endif %}"></i></icon> {{ folder }}</a>
                 {% endfor %}
                 <a class="dropdown-item {% if filters.favorited %}is-active{% endif %}" href="{{ url_for('favorites') }}">
                     <icon class="icon"><i class="far fa-star"></i></icon> favorites</a>
@@ -71,7 +71,7 @@
                         {% for folder in shortcut_folders %}
                         <li>
                             <a class="level-left {% if filters.folder == folder %}is-active"{% endif %}" href="{{ url_for('entry_list', folder=folder ) }}">
-                                <icon class="icon"><i class="far fa-folder-open"></i></icon> {{ folder }}</a>
+                                <icon class="icon"><i class="far {% if filters.folder == folder %}fa-folder-open{% else %}fa-folder{% endif %}"></i></icon> {{ folder }}</a>
                         </li>
                           {% endfor %}
                         {% endif %}

--- a/feedi/templates/feeds.html
+++ b/feedi/templates/feeds.html
@@ -31,7 +31,7 @@
                         </span>
                     </a>
                 </td>
-                <td>{% if feed.folder %}<span class="icon"><i class="far fa-folder-open"></i></span> {{ feed.folder }}{% endif %}</td>
+                <td>{% if feed.folder %}<span class="icon"><i class="far fa-folder"></i></span> {{ feed.folder }}{% endif %}</td>
 
                 <td>{% if last_seen %}{{last_seen | humanize}}{% endif %}</td>
                 <td>{{entries}}</td>


### PR DESCRIPTION
This changes the folder icons from `fa-folder-open` to `fa-folder` as the default, except when the folder is active in the sidebar. It helps to see which one is currently opened. See:

![Bildschirmfoto vom 2023-12-31 13-26-40](https://github.com/facundoolano/feedi/assets/19841886/15a38b42-6f87-4d6d-85eb-c41212fc065c)

Thanks for writing this app! I like it a lot.