### PR TITLE
fix: change dev port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
-EXPOSE 5000
+EXPOSE 9988
 
-CMD [ "gunicorn", "-b0.0.0.0:5000", "--env", "FLASK_ENV=development"]
+CMD [ "gunicorn", "-b0.0.0.0:9988", "--env", "FLASK_ENV=development"]

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,13 @@ lint:
 
 # Serve the app in development mode
 run:
-	$(flask) run --debug --reload -h 0.0.0.0
+	$(flask) run --debug --reload -h 0.0.0.0 -p 9988
 
 # Build a docker for the app container and run it
 docker:
 	mkdir -p instance
 	docker build -t feedi .
-	docker run -p 5000:5000 -v ${shell pwd}/instance:/app/instance feedi
+	docker run -p 9988:9988 -v ${shell pwd}/instance:/app/instance feedi
 
 docker-flask: CONTAINER_ID=${shell docker ps --filter "ancestor=feedi" -q}
 docker-flask:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Then, to run the app:
 
     make run
 
-The application will be available at `http://localhost:5000/`.
+The application will be available at `http://localhost:9988/`.
 
 Alternatively, you can build and run the app in a docker container with `make docker`. Read below for [non-local setup instructions](#non-local-setup).
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,4 +1,4 @@
-bind = "127.0.0.1:5000"
+bind = "127.0.0.1:9988"
 worker_class = "gevent"
 wsgi_app = "feedi.app:create_app()"
 raw_env = ["FLASK_ENV=production"]


### PR DESCRIPTION
```
$ lsof -i:5000
COMMAND     PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
ControlCe 70052 jiaqi   24u  IPv4 0xa620acf2cebbe09f      0t0  TCP *:commplex-main (LISTEN)
ControlCe 70052 jiaqi   25u  IPv6 0xa620acf2d26d27a7      0t0  TCP *:commplex-main (LISTEN)
```
I am using Mac OS
The process ControlCe is on port 5000, which is the system process Control Center and will start automatically if you kill it.

If you still want to use 5000, you can close AirPlay Receiver

![image](https://github.com/facundoolano/feedi/assets/56129212/fd631be6-c4f1-4c2b-a2eb-479f450333d8)

Considering this is inconvenient, switching ports is recommended
