### PR TITLE
Put uncompressed mimetype first in the epub zip file

### DIFF
--- a/feedi/scraping.py
+++ b/feedi/scraping.py
@@ -135,7 +135,7 @@ def package_epub(url, article):
     """
 
     output_buffer = io.BytesIO()
-    with zipfile.ZipFile(output_buffer, 'w', compression=zipfile.ZIP_DEFLATED) as zip:
+    with zipfile.ZipFile(output_buffer, 'w') as zip:
         # mimetype should be the first file in the container and it should be uncompressed
         # https://www.w3.org/TR/epub-33/#sec-zip-container-mime
         zip.writestr('mimetype', "application/epub+zip", compress_type=zipfile.ZIP_STORED)
@@ -163,7 +163,7 @@ def package_epub(url, article):
                     # else write as is
                     dest_file.write(response.content)
 
-        zip.writestr('article.html', str(soup))
+        zip.writestr('article.html', str(soup), compress_type=zipfile.ZIP_DEFLATED)
 
         # epub boilerplate based on https://github.com/thansen0/sample-epub-minimal
         zip.writestr('META-INF/container.xml', """<?xml version="1.0"?>
@@ -171,7 +171,7 @@ def package_epub(url, article):
   <rootfiles>
     <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
   </rootfiles>
-</container>""")
+</container>""", compress_type=zipfile.ZIP_DEFLATED)
 
         author = article['byline'] or article['siteName']
         if not author:
@@ -196,6 +196,6 @@ def package_epub(url, article):
   <spine toc="ncx">
    <itemref idref="article" />
   </spine>
-</package>""")
+</package>""", compress_type=zipfile.ZIP_DEFLATED)
 
     return output_buffer.getvalue()

--- a/feedi/scraping.py
+++ b/feedi/scraping.py
@@ -136,6 +136,10 @@ def package_epub(url, article):
 
     output_buffer = io.BytesIO()
     with zipfile.ZipFile(output_buffer, 'w', compression=zipfile.ZIP_DEFLATED) as zip:
+        # mimetype should be the first file in the container and it should be uncompressed
+        # https://www.w3.org/TR/epub-33/#sec-zip-container-mime
+        zip.writestr('mimetype', "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+
         soup = BeautifulSoup(article['content'], 'lxml')
         for img in soup.findAll('img'):
             img_url = img['src']
@@ -162,7 +166,6 @@ def package_epub(url, article):
         zip.writestr('article.html', str(soup))
 
         # epub boilerplate based on https://github.com/thansen0/sample-epub-minimal
-        zip.writestr('mimetype', "application/epub+zip")
         zip.writestr('META-INF/container.xml', """<?xml version="1.0"?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
   <rootfiles>


### PR DESCRIPTION
As suggested by a [hacker news comment](https://news.ycombinator.com/item?id=40803279).