### PR TITLE
Action to create and push a docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,8 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main" ]
-
+    tags:
+      - '*'
+      
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,31 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: true
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,25 @@
+FROM node:20-alpine AS node
+
 FROM python:3.11-alpine
+
+# Copy node to python-alpine image
+COPY --from=node /usr/lib /usr/lib
+COPY --from=node /usr/local/lib /usr/local/lib
+COPY --from=node /usr/local/include /usr/local/include
+COPY --from=node /usr/local/bin /usr/local/bin
 
 WORKDIR /app
 
+# Install python dependencies
 COPY requirements.txt ./
 
 RUN pip install -r requirements.txt
+
+# Install node dependencies
+# Copy both package.json and package-lock.json
+COPY package*.json ./
+
+RUN npm ci --omit=dev
 
 COPY . .
 


### PR DESCRIPTION
This PR adds a GitHub Action to automatically build a docker image for Feedi and push it as a public package in GitHub registry, which would make it the "official" docker image.

Here's how it looks on my fork: 
- action run on push to `main` branch: https://github.com/julienma/feedi/actions/workflows/docker-image.yml
- image available in GitHub Packages: https://github.com/julienma/feedi/pkgs/container/feedi

<img width="768" alt="image" src="https://github.com/facundoolano/feedi/assets/201897/79d35488-70df-4b84-bd1a-891934d071fc">

GitHub Packages is free for public repo: https://docs.github.com/en/billing/managing-billing-for-github-packages/about-billing-for-github-packages. If you prefer to publish to another registry like Docker Hub, it's trivial: https://docs.github.com/en/actions/publishing-packages/publishing-docker-images.

---

I'm using https://runtipi.io as an easy way to manage various apps.
I'd like to propose Feedi in their app directory (https://runtipi.io/docs/apps-available).

It's quite easy to propose new apps (https://runtipi.io/docs/contributing/adding-a-new-app), but this requires a public docker image for Feedi.

Even though the current Make task to build a docker image is easy, it still requires cloning the repo locally and pulling regularly. I also believe that having a public docker image always up-to-date would make it easier for more people to start using Feedi.

Happy to discuss pros/cons.

And thanks for maintaining Feedi!
